### PR TITLE
Make AddCoalToSmelter work with stacks

### DIFF
--- a/src/haven/automation/AddCoalToSmelter.java
+++ b/src/haven/automation/AddCoalToSmelter.java
@@ -8,6 +8,7 @@ import haven.Gob;
 import static haven.OCache.posres;
 import haven.Resource;
 import haven.WItem;
+import haven.res.ui.stackinv.ItemStack;
 
 public class AddCoalToSmelter implements Runnable {
     private GameUI gui;
@@ -41,6 +42,12 @@ public class AddCoalToSmelter implements Runnable {
         }
 
         WItem coalw = gui.maininv.getItemPartial("Coal");
+        if (coalw.item.getname().contains(", stack of")) {
+            coalw = ((ItemStack) coalw.item.child).wmap.values().stream().findFirst().get();
+        }
+
+
+        coalw.item.getname();
         if (coalw == null) {
             gui.error("No coal found in the inventory");
             return;


### PR DESCRIPTION
A small fix that allows script to work with stacks.

Without it if you have only stacks of coal it throws an exception and stops.

Tested by a few people on W15.