### PR TITLE
Allow drinking from containers in pouch slots

### DIFF
--- a/src/haven/purus/DrinkWater.java
+++ b/src/haven/purus/DrinkWater.java
@@ -44,13 +44,11 @@ public class DrinkWater implements Runnable {
             gui.drinkingWater = true;
             WItem drinkFromThis = null;
             Equipory e = gui.getequipory();
-            WItem l = e.quickslots[6];
-            WItem r = e.quickslots[7];
-            if (canDrinkFrom(l))
-                drinkFromThis = l;
-            if (drinkFromThis == null) {
-                if (canDrinkFrom(r))
-                    drinkFromThis = r;
+            for (WItem i : e.quickslots) {
+                if (canDrinkFrom(i)) {
+                    drinkFromThis = i;
+                    break;
+                }
             }
             if (drinkFromThis == null) {
                 for (Widget w = gui.lchild; w != null; w = w.prev) {


### PR DESCRIPTION
Currently, if you have a waterskin or glass jug in the newly-added pouch slots, drink water will not drink from them. This fixes that by trying all equipment slots.

I've tested by running this locally and drinking from a bucket in hand and waterskin in belt and inventory all still work.