### PR TITLE
Allow alt+click to transfer stacks into stockpiles and 1-item-per-tile inventories

### DIFF
--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -56,6 +56,7 @@ import java.util.stream.DoubleStream;
 public class Inventory extends Widget implements DTarget2, ItemObserver, InventoryListener {
     public static final Coord sqsz = UI.scale(33, 33);
     public static final Tex invsq/* = Resource.loadtex("gfx/hud/invsq")*/;
+    private static final Set<String> PLAYER_INVENTORY_NAMES = new HashSet<>(Arrays.asList("Inventory", "Belt", "Equipment", "Character Sheet", "Study"));
     public boolean dropul = true;
     public Coord isz;
     public boolean[] sqmask = null;

--- a/src/haven/Inventory.java
+++ b/src/haven/Inventory.java
@@ -37,6 +37,7 @@ import modification.configuration;
 import java.awt.Color;
 import java.awt.image.WritableRaster;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;


### PR DESCRIPTION
Uses "invxf2" to make this work. This sends size as second arg to avoid issues where the stack converts to a single item, leaving you with some items left in inventory.

Tested by building locally on cases:
- stacks of different sizes in inventory transfer to table, stockpile and study desk
- stack transfers without splitting into cupboard