### PR TITLE
Fix item size calculations when UI is scaled

### DIFF
--- a/src/haven/WItem.java
+++ b/src/haven/WItem.java
@@ -573,7 +573,7 @@ public class WItem extends Widget implements DTarget2 {
     public Coord size() {
         GSprite spr = item.spr();
         if (spr != null) {
-            return spr.sz().div(30);
+            return spr.sz().div(UI.getScale()).div(30);
         } else {
             return new Coord(0, 0);
         }


### PR DESCRIPTION
Steps to reproduce:
1. Go to Options > Video
2. Set UI scale to 1.50x
3. Restart your game
4. Open Xtensions > Area Picker
5. Pick boughs from trees with a 4x4 inventory
6. It will stop before your inventory is full.

Empty inventory space is calculated based on sprite size, so with larger sprites from UI scale, this gets miscalculated. This fixes it to adjust for UI scale.

I've tested manually with 1x2, 2x1, 2x2 and 1x1 items.