### PR TITLE
Fix GItem.size() when UI is scaled

### DIFF
--- a/src/haven/GItem.java
+++ b/src/haven/GItem.java
@@ -1099,7 +1099,7 @@ public class GItem extends AWidget implements ItemInfo.SpriteOwner, GSprite.Owne
     public Coord size() {
         GSprite spr = spr();
         if (spr != null) {
-            return spr.sz().div(30);
+            return spr.sz().div(UI.scale(30));
         } else {
             return new Coord(0, 0);
         }


### PR DESCRIPTION
Same as https://github.com/Cediner/ArdClient/pull/106 except for GItem. I've looked and nothing else seems to use GSprite.sz() in this way, so this should be the last one.

To reproduce this:
- set UI scale = 1.5x
- use AreaPicker to chop logs and store the wooden blocks in wooden block stockpiles. 
- With inventory size of 6 wide, 4 tall, filled with wooden blocks, click run you'll get an ArrayOutOfBoundsException.