### PR TITLE
Fix check for waiting when dropping item to inventory

### DIFF
--- a/src/haven/purus/pbot/PBotInventory.java
+++ b/src/haven/purus/pbot/PBotInventory.java
@@ -319,7 +319,7 @@ public class PBotInventory {
         int cycles = 0;
         int sleeptime = 25;
         inv.wdgmsg("drop", coord);
-        while (PBotUtils.getItemAtHand(ui) == null) {
+        while (PBotUtils.getItemAtHand(ui) != null) {
             if (cycles == limit) {
                 return (false);
             } else {


### PR DESCRIPTION
Currently, this function exits immediately before the hand is empty. The function signature suggests it should wait up until the time limit.