### PR TITLE
Fix PBotItem.coord() when UI is scaled

### DIFF
--- a/src/haven/purus/pbot/PBotItem.java
+++ b/src/haven/purus/pbot/PBotItem.java
@@ -109,7 +109,7 @@ public class PBotItem {
     }
 
     public Coord coord() {
-        return (witem.c.div(33));
+        return (witem.c.div(UI.scale(33)));
     }
 
     /**


### PR DESCRIPTION
When UI is scaled, if I try to take an item from inventory, do something with it, and then drop it back in place, it'll drop it in a different place due to scaling.

E.g. 
```
Coord originalCoord = waterskin.coord();
waterskin.takeItem(MAX_WAIT_MS);
<try to fill waterskin>
inventory.dropItemToInventory(originalCoord, MAX_WAIT_MS)
```
if UI is scaled by 1.5x, this will move the item 1.5x slots over when invoking `dropItemToInventory`.