### PR TITLE
On AreaPicker timeout for new window, check that existing windows match old ones

### DIFF
--- a/src/haven/automation/AreaPicker.java
+++ b/src/haven/automation/AreaPicker.java
@@ -1695,6 +1695,20 @@ public class AreaPicker extends Window implements Runnable {
                 sleep(sleep);
             }
         }
+
+        for (Window iw : invWindows()) {
+            boolean eq = false;
+            for (Window ow : ows)
+                if (iw.equals(ow)) {
+                    eq = true;
+                    break;
+                }
+            if (!eq) {
+                debugLog("inventory window opened", Color.WHITE);
+                return (iw);
+            }
+        }
+        
         debugLog("inventory window didn't open", Color.WHITE);
         return (null);
     }


### PR DESCRIPTION
This function can be called when `ows` had an old stockpile inventory window open and current windows has a different new stockpile inventory window open. Then, even if they have the same number of windows, they aren't the same. This makes it check at timeout just to be sure.