### PR TITLE
When Purus Pathfinder is in debug mode, output image on failure

### DIFF
--- a/src/haven/purus/pathfinder/Pathfinder.java
+++ b/src/haven/purus/pathfinder/Pathfinder.java
@@ -374,6 +374,15 @@ public class Pathfinder extends Thread {
                         synchronized (gui.map) {
                             gui.map.foundPath = false;
                         }
+                        if (DEBUG) {
+                            g.setColor(Color.WHITE);
+                            g.fillRect(destTile.x * 11+3, destTile.y * 11+3, 11-6, 11-6);
+                            try {
+                                ImageIO.write(bMap, "png", new File(System.currentTimeMillis() + "fail.png"));
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
+                        }
                         return;
                     }
 


### PR DESCRIPTION
I'm currently debugging a case where the pathfinder fails due to consobj of barter stands being treated as larger than they actually are. This helps debug that case.

Sample image:
![1736274503879fail](https://github.com/user-attachments/assets/18bdddae-2c3d-4465-b248-e964a9bec6f8)
