### PR TITLE
Properly parse hitbox for consobj

### DIFF
--- a/src/haven/sloth/script/pathfinding/Hitbox.java
+++ b/src/haven/sloth/script/pathfinding/Hitbox.java
@@ -208,7 +208,8 @@ public class Hitbox {
                 ResDrawable rd = gob.getattr(ResDrawable.class);
                 if (rd != null && rd.sdt.rbuf.length >= 4) {
                     MessageBuf buf = rd.sdt.clone();
-                    return (new Hitbox[]{new Hitbox(new Coord(buf.rbuf[0], buf.rbuf[1]), new Coord(buf.rbuf[2], buf.rbuf[3]))});
+                    Obstacle obst = Obstacle.parse(buf);
+                    return (Arrays.stream(obst.p).map(p -> new Hitbox(p, true)).toArray(Hitbox[]::new));
                 }
             }
 

--- a/src/haven/sloth/script/pathfinding/Hitbox.java
+++ b/src/haven/sloth/script/pathfinding/Hitbox.java
@@ -9,6 +9,7 @@ import haven.MessageBuf;
 import haven.RenderLink;
 import haven.ResDrawable;
 import haven.Resource;
+import haven.res.lib.obst.Obstacle;
 import haven.sloth.gob.Type;
 import haven.sloth.util.ResHashMap;
 


### PR DESCRIPTION
Duplicates fix for GobHitbox from https://github.com/Cediner/ArdClient/commit/df2445850e7e0a85291fafa6419d06319e8253d6#diff-4d2f68c9e24ca5d2b9d050a1e3c8dc8a4444664f97238d09cd3118703e227df2R189

Without this, the hitbox is very large, preventing Purus pathfinder from finding a proper path in many cases.

Before:
![1736275969701fail](https://github.com/user-attachments/assets/ee2be358-5202-423f-8f9f-c74b15797d4c)

After:
![1736276291545](https://github.com/user-attachments/assets/b65d2b26-c2af-451b-81d2-fcfaeae9c599)
