### PR TITLE
Allow Purus pathfinder to work when riding horses

### DIFF
--- a/src/haven/Gob.java
+++ b/src/haven/Gob.java
@@ -2309,7 +2309,23 @@ public class Gob implements Rendered, Sprite.Owner, Skeleton.ModOwner, Skeleton.
 //        if (homing != null && homing.tgt() != null && homing.tgt().getattr(LinMove.class) != null)
 //            return (true);
 
-        return (getattr(Moving.class) != null);
+
+        // when player is riding a horse, player is only moving if the ridden horse is also moving
+        if (getattr(Moving.class) != null) {
+            Gob riddenGob = findRiddenGob();
+            return riddenGob == null || riddenGob.isMoving();
+        }
+
+        return false;
+    }
+
+    public Gob findRiddenGob() {
+        Following follow = getattr(Following.class);
+        if (follow == null || follow.tgt() == null || follow.tgt().rc.dist((rc)) >= 0.1) {
+            return null;
+        } else {
+            return follow.tgt();
+        }
     }
 
     public LinMove getLinMove() {

--- a/src/haven/purus/pathfinder/Pathfinder.java
+++ b/src/haven/purus/pathfinder/Pathfinder.java
@@ -194,8 +194,12 @@ public class Pathfinder extends Thread {
                     }
                 }
                 long start = System.currentTimeMillis();
+                Gob riddenGob = gui.map.player().findRiddenGob();
+
                 for (Gob gob : gui.ui.sess.glob.oc.getallgobs()) {
                     if (gob.isplayer())
+                        continue;
+                    if (riddenGob != null && riddenGob.id == gob.id)
                         continue;
                     Hitbox[] box = Hitbox.hbfor(gob);
                     if (box == null) continue;


### PR DESCRIPTION
This was broken in 2 ways:
1. the horse that the player is riding counts as colliding with the player frequently
2. the player never finishes moving so the pathfinder never moves to the next step

This fixes both.
